### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/celeryweb/fixtures/sampledata.json
+++ b/celeryweb/fixtures/sampledata.json
@@ -139,7 +139,7 @@
     "fields": {
       "author": "django-better-cache", 
       "title": "Using Celery with django-better-cache", 
-      "url": "http://django-better-cache.readthedocs.org/en/latest/middleware.html", 
+      "url": "https://django-better-cache.readthedocs.io/en/latest/middleware.html", 
       "creator": "asksol", 
       "creation_date": "2012-07-29T22:48:03Z", 
       "visible": true, 
@@ -153,7 +153,7 @@
     "fields": {
       "author": "django-better-cache", 
       "title": "Using Celery with django-better-cache", 
-      "url": "http://django-better-cache.readthedocs.org/en/latest/middleware.html", 
+      "url": "https://django-better-cache.readthedocs.io/en/latest/middleware.html", 
       "creator": "asksol", 
       "creation_date": "2012-07-29T22:48:03Z", 
       "visible": true, 


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.