### PR TITLE
Add feed to news page

### DIFF
--- a/celeryproject/settings/base.py
+++ b/celeryproject/settings/base.py
@@ -35,7 +35,7 @@ USE_I18N = True
 # calendars according to the current locale.
 USE_L10N = True
 
-LOCALE_PATHS = (join(PROJECT_ROOT, 'celeryweb/locale'))
+LOCALE_PATHS = (join(PROJECT_ROOT, 'celeryweb/locale'),)
 
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = True

--- a/celeryproject/urls.py
+++ b/celeryproject/urls.py
@@ -6,6 +6,7 @@ from celeryweb import views
 
 urlpatterns = [url(r'^news/$', views.news, name='news'),
                url(r'^news/(?P<slug>[\w-]*)', views.news, name='news_entry'),
+               url(r'^news/feed/$', views.NewsFeed(), name='news_feed'),
                url(r'^tutorials/$', views.tutorials, name='tutorials'),
                url(r'^tutorials/(?P<slug>[\w-]*)',
                    views.tutorials, name='tutorial'),

--- a/celeryweb/models.py
+++ b/celeryweb/models.py
@@ -6,7 +6,6 @@ from django.contrib.auth.models import User
 from django.contrib.flatpages.models import FlatPage
 from django.utils.translation import ugettext_lazy as _
 
-
 class TrackingModel(models.Model):
     creator = models.CharField(verbose_name=_("_creator"),
                                max_length=255,
@@ -103,7 +102,6 @@ class News(TrackingModel):
 
     def permalink(self):
         return "/news/%s/" % self.slug
-
 
 class Tutorial(TrackingModel):
     title = models.CharField(verbose_name=_("_title"), max_length=255)

--- a/celeryweb/views.py
+++ b/celeryweb/views.py
@@ -7,6 +7,8 @@ from django.template import RequestContext
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404, render
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
+from django.contrib.syndication.views import Feed
+from django.urls import reverse
 
 from .models import News, Tutorial, CommunityLink
 
@@ -140,3 +142,21 @@ def package_info(request):
         'ajax/celery_package_info.html',
         package_info_context,
     )
+
+class NewsFeed(Feed):
+    title = "News | Celery: Distributed Task Queue"
+    link = "/sitenews/"
+    description = "News"
+
+    def items(self):
+        return News.objects.order_by('-pub_date')[:5]
+
+    def item_title(self, item):
+        return item.title
+
+    def item_description(self, item):
+        return item.text
+
+    # item_link is only needed if NewsItem has no get_absolute_url method.
+    def item_link(self, item):
+        return reverse('news_entry', args=[item.slug])

--- a/templates/news.html
+++ b/templates/news.html
@@ -1,6 +1,8 @@
 {%extends "base.html" %}
 {% load url from future %}
 {%block title%}News{%endblock%}
+<link rel="alternate" type="application/rss+xml"
+  href="{% site_url %}/news/feed" title="Celery Project News">
 {%block content%}
   <h1>News</h1>
   <div class="list">


### PR DESCRIPTION
This is an early stage and it is not tested yet. I think it would be nice that it is possible to subscribe to the news of the celery project. Therefore, I've added a RSS view. This is not tested yet and in an early stage. Perhaps someone wants to give some hints or comments.